### PR TITLE
Fix Cannot read property 'getDomNode' of undefined

### DIFF
--- a/lib/analyzer/hyperlink.js
+++ b/lib/analyzer/hyperlink.js
@@ -98,5 +98,9 @@ module.exports = function(editor, registry) {
 };
 
 function getLinesDomNode(view) {
-    return view.component ? view.component.linesComponent.getDomNode() : view;
+    if (view.component.refs != null) {
+      return view.component.refs.lineTiles;
+    } else {
+      return view.component.linesComponent.getDomNode()
+    }
 }


### PR DESCRIPTION
Cannot read property 'getDomNode' of undefined.
Closes #30 #34 #35